### PR TITLE
speedometer picklist value usage added

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -8,9 +8,9 @@ Copyright end */
     .module('cybersponse')
     .controller('speedometer100Ctrl', speedometer100Ctrl);
 
-  speedometer100Ctrl.$inject = ['$scope', 'widgetUtilityService', 'config', '$state', 'speedometerService', 'modelMetadatasService', '$rootScope', 'localStorageService', '_'];
+  speedometer100Ctrl.$inject = ['$q','$scope', 'widgetUtilityService', 'config', '$state', 'speedometerService', 'modelMetadatasService', '$rootScope', 'localStorageService', '_'];
 
-  function speedometer100Ctrl($scope, widgetUtilityService, config, $state, speedometerService, modelMetadatasService, $rootScope, localStorageService, _) {
+  function speedometer100Ctrl($q, $scope, widgetUtilityService, config, $state, speedometerService, modelMetadatasService, $rootScope, localStorageService, _) {
 
     $scope.config = config;
     $scope.pageState = $state;
@@ -68,9 +68,10 @@ Copyright end */
 
     function updateSpeedometer(percentage) {
       $scope.riskPercentage = percentage ? percentage : 0;
-      $scope.startRiskColor = getRiskScorePicklistColor($scope.scoreField).startRiskColor;
-      $scope.stopRiskColor = getRiskScorePicklistColor($scope.scoreField).endRiskColor;
-
+      getRiskScorePicklistColor($scope.scoreField).then(function(response){
+        $scope.startRiskColor = response.startRiskColor;
+        $scope.stopRiskColor = response.endRiskColor;
+      });
       const startAngle = 135; // Ensure alignment with background arc's start
       const endAngle = 135 + (percentage / 100) * 270; // Map percentage to 180-degree span
       const path = document.getElementById("progress-arc");
@@ -90,17 +91,29 @@ Copyright end */
       }, 10);
     }
 
-    //map risk color for grid risk column through Confidence picklist value
+    //map risk color for speedometer through Confidence picklist value using entity form fields
     function getRiskScorePicklistColor(riskKey) {
-      const _picklistField = 'IOC Search Confidence';
-      let picklists = localStorageService.get('picklists.' + _picklistField);
-      let color = '';
-      _.filter(picklists, function (element) {
-        if (element.itemValue === riskKey) {
-          color = element.color;
+      var defer = $q.defer();
+      var entity = new Entity($scope.config.resource);
+      entity.loadFields().then(function () {
+        let formFields = entity.getFormFields();
+        let _picklistValues = _.filter(formFields, function (field) {
+          return field.type === 'picklist' && field.name === $scope.config.picklistField;
+        });
+        if(_picklistValues.length > 0){
+          let color = '';
+          _.filter(_picklistValues[0].options, function (element) {
+            if (element.itemValue === riskKey) {
+              color = element.color;
+            }
+          });
+          defer.resolve({'startRiskColor' : color,  'endRiskColor': speedometerService.generateGradient(color, -30)});
+        }
+        else{
+          defer.reject();
         }
       });
-      return {'startRiskColor' : color,  'endRiskColor': speedometerService.generateGradient(color, -30)};
+      return defer.promise;
     }
 
     function checkCurrentPage(state){

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -8,9 +8,9 @@ Copyright end */
     .module('cybersponse')
     .controller('speedometer100Ctrl', speedometer100Ctrl);
 
-  speedometer100Ctrl.$inject = ['$scope', 'widgetUtilityService', 'config', '$state', 'speedometerService', 'modelMetadatasService', '$rootScope' ];
+  speedometer100Ctrl.$inject = ['$scope', 'widgetUtilityService', 'config', '$state', 'speedometerService', 'modelMetadatasService', '$rootScope', 'localStorageService', '_'];
 
-  function speedometer100Ctrl($scope, widgetUtilityService, config, $state, speedometerService, modelMetadatasService, $rootScope) {
+  function speedometer100Ctrl($scope, widgetUtilityService, config, $state, speedometerService, modelMetadatasService, $rootScope, localStorageService, _) {
 
     $scope.config = config;
     $scope.pageState = $state;
@@ -68,8 +68,8 @@ Copyright end */
 
     function updateSpeedometer(percentage) {
       $scope.riskPercentage = percentage ? percentage : 0;
-      $scope.startRiskColor = mapRiskColor($scope.scoreField).startRiskColor;
-      $scope.stopRiskColor = mapRiskColor($scope.scoreField).endRiskColor;
+      $scope.startRiskColor = getRiskScorePicklistColor($scope.scoreField).startRiskColor;
+      $scope.stopRiskColor = getRiskScorePicklistColor($scope.scoreField).endRiskColor;
 
       const startAngle = 135; // Ensure alignment with background arc's start
       const endAngle = 135 + (percentage / 100) * 270; // Map percentage to 180-degree span
@@ -89,27 +89,18 @@ Copyright end */
         needle.style.transform = `rotate(${needleAngle}deg)`;
       }, 10);
     }
-  
-    function mapRiskColor(riskKey){
-      if (typeof riskKey != 'string') {
-        return '';
-      }
-      switch (riskKey.toLowerCase().trim()) {
-        case 'high':
-          return {'startRiskColor' : '#F66E4F',  'endRiskColor': '#E60C4B'};
-          break;
-        case 'low':
-          return {'startRiskColor' : '#fdfc00',  'endRiskColor': '#fac602'};
-          break;
-        case 'moderate':
-          return {'startRiskColor' : '#07de04',  'endRiskColor': '#6ac359'};
-          break;
-        case 'default':
-          return {'startRiskColor' : '#5596be',  'endRiskColor': '#1d7fbb'};
-        default:
-          return 
 
-      }
+    //map risk color for grid risk column through Confidence picklist value
+    function getRiskScorePicklistColor(riskKey) {
+      const _picklistField = 'IOC Search Confidence';
+      let picklists = localStorageService.get('picklists.' + _picklistField);
+      let color = '';
+      _.filter(picklists, function (element) {
+        if (element.itemValue === riskKey) {
+          color = element.color;
+        }
+      });
+      return {'startRiskColor' : color,  'endRiskColor': speedometerService.generateGradient(color, -30)};
     }
 
     function checkCurrentPage(state){

--- a/widget/widgetAssets/js/speedometer.service.js
+++ b/widget/widgetAssets/js/speedometer.service.js
@@ -2,76 +2,109 @@
     MIT License
     Copyright (c) 2025 Fortinet Inc
 Copyright end */
-  'use strict';
+'use strict';
 
-  (function () {
-      angular
-          .module('cybersponse')
-          .factory('speedometerService', speedometerService);
-  
-      speedometerService.$inject = ['$q', '$http', 'Query', 'API', 'ALL_RECORDS_SIZE', '$resource', 'connectorService'];
-  
-      function speedometerService($q, $http, Query, API, ALL_RECORDS_SIZE, $resource, connectorService) {
-          var service;
-          service = {
-              getResourceAggregate: getResourceAggregate,
-              executeAction: executeAction
-          };
-  
-          //to fetch modules data through API query
-          function getResourceAggregate(_config) {
-              var defer = $q.defer();
-              var queryObject = {
-                  aggregates: [
-                      {
-                          'operator': 'count',
-                          'field': '*',
-                          'alias': 'total'
-                      },
-                      {
-                          "operator": "groupby",
-                          "alias": _config.picklistField,
-                          "field": _config.picklistField + '.itemValue'
-                      },
-                      {
-                          "operator": "groupby",
-                          "alias": "color",
-                          "field": _config.picklistField + ".color"
-                      }
-                  ],
-                  relationship: true
-              };
-              var _queryObj = new Query(queryObject);
-              $http.post(API.QUERY + _config.resource + '?$limit=' + ALL_RECORDS_SIZE, _queryObj.getQuery(true)).then(function (response) {
-                  defer.resolve(response);
-              }, function (error) {
-                  defer.reject(error);
-              });
-              return defer.promise;
-          }
-  
-          //execute connection action
-          function executeAction(connector_name, connector_action, payload) {
-              return $resource(API.INTEGRATIONS + 'connectors/?name=' + connector_name)
-                  .get()
-                  .$promise
-                  .then(function (connectorMetaDataForVersion) {
-                      let defaultConfig = connectorMetaDataForVersion.data[0].configuration.filter(item => item.default);
-                      if (defaultConfig) {
-                          var config_id = defaultConfig[0]['config_id'];
-                      }
-                      else {
-                          toaster.error({ body: 'Default configuration not present.' });
-                      }
-                      return connectorService.executeConnectorAction(connector_name, connectorMetaDataForVersion.data[0].version, connector_action, config_id, payload);
-                  })
-                  .catch(function (error) {
-                      console.error('Error:', error);
-                      throw error; // Rethrow the error to be handled by the caller
-                  });
-          }
-  
-          return service;
-      }
-  })();
-  
+(function () {
+    angular
+        .module('cybersponse')
+        .factory('speedometerService', speedometerService);
+
+    speedometerService.$inject = ['$q', '$http', 'Query', 'API', 'ALL_RECORDS_SIZE', '$resource', 'connectorService'];
+
+    function speedometerService($q, $http, Query, API, ALL_RECORDS_SIZE, $resource, connectorService) {
+        var service;
+        service = {
+            getResourceAggregate: getResourceAggregate,
+            executeAction: executeAction,
+            generateGradient: generateGradient
+        };
+
+        //to fetch modules data through API query
+        function getResourceAggregate(_config) {
+            var defer = $q.defer();
+            var queryObject = {
+                aggregates: [
+                    {
+                        'operator': 'count',
+                        'field': '*',
+                        'alias': 'total'
+                    },
+                    {
+                        "operator": "groupby",
+                        "alias": _config.picklistField,
+                        "field": _config.picklistField + '.itemValue'
+                    },
+                    {
+                        "operator": "groupby",
+                        "alias": "color",
+                        "field": _config.picklistField + ".color"
+                    }
+                ],
+                relationship: true
+            };
+            var _queryObj = new Query(queryObject);
+            $http.post(API.QUERY + _config.resource + '?$limit=' + ALL_RECORDS_SIZE, _queryObj.getQuery(true)).then(function (response) {
+                defer.resolve(response);
+            }, function (error) {
+                defer.reject(error);
+            });
+            return defer.promise;
+        }
+
+        //execute connection action
+        function executeAction(connector_name, connector_action, payload) {
+            return $resource(API.INTEGRATIONS + 'connectors/?name=' + connector_name)
+                .get()
+                .$promise
+                .then(function (connectorMetaDataForVersion) {
+                    let defaultConfig = connectorMetaDataForVersion.data[0].configuration.filter(item => item.default);
+                    if (defaultConfig) {
+                        var config_id = defaultConfig[0]['config_id'];
+                    }
+                    else {
+                        toaster.error({ body: 'Default configuration not present.' });
+                    }
+                    return connectorService.executeConnectorAction(connector_name, connectorMetaDataForVersion.data[0].version, connector_action, config_id, payload);
+                })
+                .catch(function (error) {
+                    console.error('Error:', error);
+                    throw error; // Rethrow the error to be handled by the caller
+                });
+        }
+
+        /**
+         * @ngdoc method
+         * @name fortitip.generateGradient
+         * @methodOf fortitip.speedometerService
+         *
+         * @description
+         * This generate gradient stop color for speedometer arc fill and returns the gradient stop color
+         *
+         * @param  {String} color color whose gradient has to be generated
+         * @param  {Number} percent depth of darkness of the color, Negative values is more darker
+         * @return {String}  returns the gradient stop color
+        */
+        function generateGradient(color, percent) {
+            // Function to adjust brightness
+            let R = parseInt(color.substring(1, 3), 16);
+            let G = parseInt(color.substring(3, 5), 16);
+            let B = parseInt(color.substring(5, 7), 16);
+
+            R = parseInt((R * (100 + percent)) / 100);
+            G = parseInt((G * (100 + percent)) / 100);
+            B = parseInt((B * (100 + percent)) / 100);
+
+            R = R < 255 ? R : 255;
+            G = G < 255 ? G : 255;
+            B = B < 255 ? B : 255;
+
+            let RR = (R.toString(16).length == 1 ? "0" + R.toString(16) : R.toString(16));
+            let GG = (G.toString(16).length == 1 ? "0" + G.toString(16) : G.toString(16));
+            let BB = (B.toString(16).length == 1 ? "0" + B.toString(16) : B.toString(16));
+
+            return "#" + RR + GG + BB;
+        }
+
+        return service;
+    }
+})();


### PR DESCRIPTION
generateGradient function added in speedometer service to use confidence picklist color  and generate gradient stop color

UTC's
- [x] when clicked from grid the speedometer loads in SVT
- [x] the color of the speedometer should match the Grid Risk Score column color and the SVT heading color
- [x] the color fill should be gradient

![Screenshot 2025-01-07 at 2 33 23 PM](https://github.com/user-attachments/assets/8c30a630-e374-4e43-855b-12a904319f13)


![Screenshot 2025-01-07 at 2 33 01 PM](https://github.com/user-attachments/assets/59bd8a4f-3246-4ffe-8007-6784c7815482)
